### PR TITLE
Make favorite items portal compatible to new Engage versions

### DIFF
--- a/frontend/portals/ProductPropertiesFav/index.jsx
+++ b/frontend/portals/ProductPropertiesFav/index.jsx
@@ -3,16 +3,16 @@ import PropTypes from 'prop-types';
 import { useTargetConfigs } from '../../properties/hooks';
 import ProductPropertiesCmp from '../../components/ProductProperties';
 import { filterProperties } from '../../properties/helpers';
+import { withPropertiesByProductId } from '../../properties/connectors';
 
 /**
  * @param {Object} props Props
  * @return {JSX}
  */
-const ProductPropertiesFav = ({ name, product }) => {
+const ProductPropertiesFav = ({ name, properties }) => {
   const configs = useTargetConfigs(name);
 
-  const { additionalProperties } = product || {};
-  if (!additionalProperties || !configs) {
+  if (!properties || !configs) {
     return null;
   }
 
@@ -26,7 +26,7 @@ const ProductPropertiesFav = ({ name, product }) => {
           formats={config.formats}
           isHtml={config.html === true}
           useDefaultLayout={config.use_default_layout === true}
-          properties={filterProperties(additionalProperties, config)}
+          properties={filterProperties(properties, config)}
         />
       ))}
     </Fragment>
@@ -35,7 +35,13 @@ const ProductPropertiesFav = ({ name, product }) => {
 
 ProductPropertiesFav.propTypes = {
   name: PropTypes.node.isRequired,
-  product: PropTypes.shape().isRequired,
+  properties: PropTypes.arrayOf(PropTypes.shape()),
 };
 
-export default memo(ProductPropertiesFav);
+ProductPropertiesFav.defaultProps = {
+  properties: null,
+};
+
+export default withPropertiesByProductId(
+  memo(ProductPropertiesFav)
+);

--- a/frontend/properties/connectors.js
+++ b/frontend/properties/connectors.js
@@ -7,8 +7,20 @@ import { getPropertiesByCartItemId, makeGetPropertiesByProductId } from './selec
 export const withPropertiesByProductId = connect((state, props) => {
   const getPropertiesByProductId = makeGetPropertiesByProductId();
 
+  let mapProps = props;
+  if (!mapProps.productId && mapProps.id) {
+    mapProps = {
+      productId: mapProps.id,
+    };
+  }
+  if (!mapProps.productId && mapProps.product) {
+    mapProps = {
+      productId: mapProps.product.id,
+    };
+  }
+
   return {
-    properties: getPropertiesByProductId(state, props),
+    properties: getPropertiesByProductId(state, mapProps),
   };
 });
 


### PR DESCRIPTION
## Description

Make favorite items portal compatible to new Engage versions

## Type of change

- [] Bug fix
- [X] New feature
- [ ] This change requires a documentation update
